### PR TITLE
Fix init.done stop condition

### DIFF
--- a/modules/install-k8s/k8s-init
+++ b/modules/install-k8s/k8s-init
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # Do not run if init has already been done
-if [ -f /opt/kubeadm/init.done ]; then
+if [ -f /opt/k8s/init.done ]; then
    echo "init already done." >&1
    exit 0
 fi


### PR DESCRIPTION
Not sure if correct but I cannot found any other references to `/opt/kubeadm/init.done`, thus it seems there is only one `init.done` located in `/opt/k8s`.