### PR TITLE
Remove ssh_private_key and ssh_bastion_private_key variables

### DIFF
--- a/examples/private-cluster-cl/README.md
+++ b/examples/private-cluster-cl/README.md
@@ -38,7 +38,7 @@ Please enter your OpenStack Password:
 $ ssh-keygen -f terraform_ssh_key -q -N ""
 ```
 
-If you generate a new keypair, put its path in `terraform.tfvars` undar variables `private_sshkey` and `public_sshkey`.
+If you generate a new keypair, put its path in `terraform.tfvars` under variable `public_sshkey`.
 
 ## Run it
 

--- a/examples/private-cluster-cl/main.tf
+++ b/examples/private-cluster-cl/main.tf
@@ -41,8 +41,6 @@ module "k8s" {
   ignition_mode           = true
   ssh_user                = "core"
   ssh_authorized_keys     = ["${file("${var.public_sshkey}")}"]
-  ssh_private_key         = "${file("${var.private_sshkey}")}"
-  ssh_bastion_private_key = "${file("${var.private_sshkey}")}"
   ssh_bastion_host        = "${module.network.bastion_public_ip}"
   ssh_bastion_user        = "core"
   associate_public_ipv4   = false

--- a/examples/private-cluster-cl/terraform.tfvars.sample
+++ b/examples/private-cluster-cl/terraform.tfvars.sample
@@ -1,4 +1,3 @@
 os_region_name = "DE1"
 os_flavor_name = "b2-7"
-private_sshkey = "~/.ssh/id_rsa"
 public_sshkey = "~/.ssh/id_rsa.pub"

--- a/examples/private-cluster-cl/variables.tf
+++ b/examples/private-cluster-cl/variables.tf
@@ -27,11 +27,6 @@ variable "count" {
   default     = 3
 }
 
-variable "private_sshkey" {
-  description = "Key to use to ssh connect"
-  default     = "~/.ssh/id_rsa"
-}
-
 variable "public_sshkey" {
   description = "Key to use to ssh connect"
   default     = "~/.ssh/id_rsa.pub"

--- a/examples/public-cluster-cl/README.md
+++ b/examples/public-cluster-cl/README.md
@@ -38,7 +38,7 @@ Please enter your OpenStack Password:
 $ ssh-keygen -f terraform_ssh_key -q -N ""
 ```
 
-If you generate a new keypair, put its path in `terraform.tfvars` undar variables `private_sshkey` and `public_sshkey`.
+If you generate a new keypair, put its path in `terraform.tfvars` under variable `public_sshkey`.
 
 ## Run it
 

--- a/examples/public-cluster-cl/main.tf
+++ b/examples/public-cluster-cl/main.tf
@@ -39,7 +39,6 @@ module "k8s" {
   public_security_group_ids = ["${openstack_networking_secgroup_v2.sg.id}"]
   ssh_user                  = "core"
   ssh_authorized_keys       = ["${file("${var.public_sshkey}")}"]
-  ssh_private_key           = "${file("${var.private_sshkey}")}"
   associate_public_ipv4     = true
   associate_private_ipv4    = false
   master_as_worker          = true

--- a/examples/public-cluster-cl/terraform.tfvars.sample
+++ b/examples/public-cluster-cl/terraform.tfvars.sample
@@ -1,4 +1,3 @@
 os_region_name = "DE1"
 os_flavor_name = "b2-7"
-private_sshkey = "~/.ssh/id_rsa"
 public_sshkey = "~/.ssh/id_rsa.pub"

--- a/examples/public-cluster-cl/variables.tf
+++ b/examples/public-cluster-cl/variables.tf
@@ -27,11 +27,6 @@ variable "count" {
   default     = 3
 }
 
-variable "private_sshkey" {
-  description = "Key to use to ssh connect"
-  default     = "~/.ssh/id_rsa"
-}
-
 variable "public_sshkey" {
   description = "Key to use to ssh connect"
   default     = "~/.ssh/id_rsa.pub"

--- a/main.tf
+++ b/main.tf
@@ -213,10 +213,8 @@ module "post_install_cfssl" {
   triggers                = ["${element(concat(openstack_compute_instance_v2.singlenet_k8s.*.id, openstack_compute_instance_v2.multinet_k8s.*.id), 0)}"]
   ipv4_addrs              = ["${element(concat(openstack_compute_instance_v2.singlenet_k8s.*.access_ip_v4, openstack_compute_instance_v2.multinet_k8s.*.access_ip_v4), 0)}"]
   ssh_user                = "${var.ssh_user}"
-  ssh_private_key         = "${var.ssh_private_key}"
   ssh_bastion_host        = "${var.ssh_bastion_host}"
   ssh_bastion_user        = "${var.ssh_bastion_user}"
-  ssh_bastion_private_key = "${var.ssh_bastion_private_key}"
 }
 
 module "post_install_etcd" {

--- a/main.tf
+++ b/main.tf
@@ -225,10 +225,8 @@ module "post_install_etcd" {
   triggers                = ["${concat(openstack_compute_instance_v2.singlenet_k8s.*.id, openstack_compute_instance_v2.multinet_k8s.*.id)}"]
   ipv4_addrs              = ["${concat(openstack_compute_instance_v2.singlenet_k8s.*.access_ip_v4, openstack_compute_instance_v2.multinet_k8s.*.access_ip_v4)}"]
   ssh_user                = "${var.ssh_user}"
-  ssh_private_key         = "${var.ssh_private_key}"
   ssh_bastion_host        = "${var.ssh_bastion_host}"
   ssh_bastion_user        = "${var.ssh_bastion_user}"
-  ssh_bastion_private_key = "${var.ssh_bastion_private_key}"
 }
 
 module "post_install_k8s" {
@@ -237,10 +235,8 @@ module "post_install_k8s" {
   triggers                = ["${concat(openstack_compute_instance_v2.singlenet_k8s.*.id, openstack_compute_instance_v2.multinet_k8s.*.id)}"]
   ipv4_addrs              = ["${concat(openstack_compute_instance_v2.singlenet_k8s.*.access_ip_v4, openstack_compute_instance_v2.multinet_k8s.*.access_ip_v4)}"]
   ssh_user                = "${var.ssh_user}"
-  ssh_private_key         = "${var.ssh_private_key}"
   ssh_bastion_host        = "${var.ssh_bastion_host}"
   ssh_bastion_user        = "${var.ssh_bastion_user}"
-  ssh_bastion_private_key = "${var.ssh_bastion_private_key}"
 }
 
 # This is somekind of a hack to ensure that when instances ids are output and made

--- a/modules/install-k8s/main.tf
+++ b/modules/install-k8s/main.tf
@@ -8,10 +8,8 @@ resource "null_resource" "post_install_k8s" {
   connection {
     host                = "${element(var.ipv4_addrs, count.index)}"
     user                = "${var.ssh_user}"
-    private_key         = "${var.ssh_private_key}"
     bastion_host        = "${var.ssh_bastion_host}"
     bastion_user        = "${var.ssh_bastion_user}"
-    bastion_private_key = "${var.ssh_bastion_private_key}"
   }
 
   provisioner "remote-exec" {

--- a/modules/install-k8s/variables.tf
+++ b/modules/install-k8s/variables.tf
@@ -23,10 +23,6 @@ variable "install_dir" {
   default     = "/opt/k8s"
 }
 
-variable "ssh_private_key" {
-  description = "The ssh private key used to post provision the k8s cluster. This is required if `post_install_module` is set to `true`. It must be set accordingly to `ssh_key_pair"
-}
-
 variable "ssh_bastion_host" {
   description = "The address of the bastion host used to post provision the k8s cluster. This may be required if `post_install_module` is set to `true`"
   default     = ""
@@ -34,11 +30,6 @@ variable "ssh_bastion_host" {
 
 variable "ssh_bastion_user" {
   description = "The ssh username of the bastion host used to post provision the k8s cluster. This may be required if `post_install_module` is set to `true`"
-  default     = ""
-}
-
-variable "ssh_bastion_private_key" {
-  description = "The ssh private key of the bastion host used to post provision the k8s cluster. This may be required if `post_install_module` is set to `true`"
   default     = ""
 }
 

--- a/test/runtest.sh
+++ b/test/runtest.sh
@@ -23,6 +23,9 @@ test_tf(){
     return $res
 }
 
+if [ ! -f "$SSH_AUTH_SOCK" ]; then
+    eval $(ssh-agent) && ssh-add ${TEST_SSH_PRIVATE_KEY:-$HOME/.ssh/id_rsa}
+fi
 
 # if destroy mode, clean previous terraform setup
 if [ "${CLEAN}" == "1" ]; then

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -3,6 +3,10 @@
 REGIONS=${1:-$OS_REGION_NAME}
 DIRS=(public-cluster-cl private-cluster-cl)
 
+if [ ! -f "$SSH_AUTH_SOCK" ]; then
+    eval $(ssh-agent) && ssh-add ${TEST_SSH_PRIVATE_KEY:-$HOME/.ssh/id_rsa}
+fi
+
 EXIT=0
 for d in ${DIRS[@]}; do
     for r in $REGIONS; do

--- a/variables.tf
+++ b/variables.tf
@@ -126,11 +126,6 @@ variable "ssh_user" {
   default     = "core"
 }
 
-variable "ssh_private_key" {
-  description = "The ssh private key used to post provision the k8s cluster. This is required if `post_install_module` is set to `true`. It must be set accordingly to `ssh_key_pair"
-  default     = ""
-}
-
 variable "ssh_bastion_host" {
   description = "The address of the bastion host used to post provision the k8s cluster. This may be required if `post_install_module` is set to `true`"
   default     = ""
@@ -138,11 +133,6 @@ variable "ssh_bastion_host" {
 
 variable "ssh_bastion_user" {
   description = "The ssh username of the bastion host used to post provision the k8s cluster. This may be required if `post_install_module` is set to `true`"
-  default     = ""
-}
-
-variable "ssh_bastion_private_key" {
-  description = "The ssh private key of the bastion host used to post provision the k8s cluster. This may be required if `post_install_module` is set to `true`"
   default     = ""
 }
 


### PR DESCRIPTION
The commit ovh/terraform-ovh-publiccloud-cfssl@89d51c2c374f34c60222989c6af66d5d7ee3597f remove variables `ssh_private_key` and `ssh_bastion_private_key`. This commit removes these two variables from module `post_install_cfssl`.