### PR TITLE
Improve user experiences

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,8 @@ This module has the following folder structure:
 To deploy K8s servers using this Module:
 
 1. (Optional) Create a K8s Glance Image using a Packer template that references the [install-k8s module](https://github.com/ovh/terraform-ovh-publiccloud-k8s/tree/master/modules/install-k8s).
-   Here is an [example Packer template](https://github.com/ovh/terraform-ovh-publiccloud-k8s/tree/master/examples/k8s-glance-image#quick-start). 
-      
-1. Deploy that Image using the Terraform [k8s-cluster example](https://github.com/ovh/terraform-ovh-publiccloud-k8s/tree/master/examples/k8s-cluster). If you prebuilt a k8s glance image with packer, you can comment the post provisionning modules arguments.
+   Here is an [example Packer template](https://github.com/ovh/terraform-ovh-publiccloud-k8s/tree/master/examples/k8s-glance-image#quick-start).
+1. Deploy that Image using one of the Terraform cluster example: [private cluster](https://github.com/ovh/terraform-ovh-publiccloud-k8s/tree/master/examples/private-cluster-cl) or [public cluster](https://github.com/ovh/terraform-ovh-publiccloud-k8s/tree/master/examples/public-cluster-cl). If you prebuilt a k8s glance image with packer, you can comment the post provisionning modules arguments.
 
 ## Flavors
 

--- a/examples/private-cluster-cl/README.md
+++ b/examples/private-cluster-cl/README.md
@@ -4,44 +4,46 @@
 - [Simple k8s cluster](#simple-k8s-cluster)
     - [Configuration](#configuration)
     - [Run it](#run-it)
+    - [Get started](#get-started)
     
 ## Install terraform
 
 You can information on how to install terraform [here](https://www.terraform.io/intro/getting-started/install.html)
 
 ## Configuration
-1. Copy variable file
 
-There is an example of var file `terraform.tfvars.sample`.
+1. Copy variable file, then edit it if needed.
+   This allow terraform to autoload those variables
 
-Copy it under the name `terraform.tfvars` (this allow terraform to autoload those variables)
+   ```bash
+   cp terraform.tfvars.sample terraform.tfvars
+   ```
 
-2. Create a public cloud project on OVH
+2. Create a public cloud project on OVH following the [official documentation](https://docs.ovh.com/gb/en/public-cloud/getting_started_with_public_cloud_logging_in_and_creating_a_project/).
 
-Follow the [official documentation](https://docs.ovh.com/gb/en/public-cloud/getting_started_with_public_cloud_logging_in_and_creating_a_project/).
+   Create a VRack and add it to the Openstack project.
 
-You will need to create an Openstack user. You can do so in the "Openstack" part of you cloud project. 
+   Create an Openstack user ([official documentation](https://docs.ovh.com/gb/en/public-cloud/configure_user_access_to_horizon/)).
+   Then download the Openstack configuration file. You can get it from [OVH Manager](https://www.ovh.com/manager/cloud/), or from [Horizon interface](https://horizon.cloud.ovh.net/project/api_access/openrc/).
 
-You add to source your openstack configuration file. You can generate this file for you user in OVH manager (Use the user contextual menu). 
+   Source the configuration file:
 
-```bash
-# Source openrc.sh
-$ source openrc.sh
-Please enter your OpenStack Password: 
+   ```bash
+   $ source openrc.sh
+   Please enter your OpenStack Password:
 
-```
+   ```
 
-3. Create or reuse ssh key pair. Carreful this keypair should not be using passphrase !
+3. Create or reuse ssh key pair. Careful this keypair should not be using passphrase!
 
-```bash
-# Generate a new keypair without passphrase
-$ ssh-keygen -f terraform_ssh_key -q -N ""
-```
+   ```bash
+   # Generate a new keypair without passphrase
+   $ ssh-keygen -f terraform_ssh_key -q -N ""
+   # Add it to the ssh-agent
+   $ ssh-add terraform_ssh_key
+   ```
 
-If you generate a new keypair, put its path in `terraform.tfvars` under variable `public_sshkey` and add it to your ssh-agent:
-```bash
-$ ssh-add terraform_ssh_key
-```
+   If you generated a new keypair, set `public_sshkey` with its path in `terraform.tfvars`.
 
 ## Run it
 
@@ -55,28 +57,36 @@ Terraform has been successfully initialized!
 
 $ terraform apply
 [...]
-helper = Your kubernetes cluster is up.
 
-You can connect in one of the instances:
-
-    $ ssh -J core@<ip-bastion> core@<ip>
-
-Check your etcd cluster:
-
-    $ /opt/etcd/bin/etcdctl --ca-file /opt/etcd/certs/ca.pem --cert-file /opt/etcd/certs/cert.pem --key-file /opt/etcd/certs/cert-key.pem --endpoints https://54.36.112.50:2379 member list
-
-
-Check your k8s cluster:
-
-    $ sudo /opt/k8s/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf get nodes
-
-Run a pod:
-
-    $ ...
-
-Enjoy!
 ```
 
 This should give you an infra with :
 
 - 3 kubernetes host in a private network.
+
+## Get Started
+
+Get help with following command:
+
+```bash
+$ terraform output helper
+Your kubernetes cluster is up.
+
+Check if cluster is running:
+
+    $ [...]
+
+Configure the client:
+
+    $ [...]
+
+To connect to one of the instances:
+
+    $ [...]
+
+Run a pod:
+
+    $ [...]
+
+Enjoy!
+```

--- a/examples/private-cluster-cl/output.tf
+++ b/examples/private-cluster-cl/output.tf
@@ -1,28 +1,28 @@
 locals {
-  etcd_test_command = "/opt/etcd/bin/etcdctl --ca-file /opt/etcd/certs/ca.pem --cert-file /opt/etcd/certs/cert.pem --key-file /opt/etcd/certs/cert-key.pem --endpoints https://${module.k8s.private_ipv4_addrs[0]}:2379 member list"
-  k8s_test_command  = "sudo /opt/k8s/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf get nodes"
-}
+  k8s_config_path = "~/.kube/config"
 
-output "tf_test_etcd" {
-  description = "This output can be used to check if the cluster is up & running by typing `terraform output tf_test | sh`"
+  ssh_prefix = <<CMD
+ssh -o ProxyCommand='ssh -o StrictHostKeyChecking=no core@${module.network.bastion_public_ip} ncat %h %p' \
+    core@${module.k8s.private_ipv4_addrs[0]} -- \
+  CMD
 
-  value = <<TEST
+  test_ssh_prefix = <<CMD
 ssh -o UserKnownHostsFile=/dev/null \
     -o StrictHostKeyChecking=no \
     -o ProxyCommand='ssh -o StrictHostKeyChecking=no core@${module.network.bastion_public_ip} ncat %h %p' \
-    core@${module.k8s.private_ipv4_addrs[0]} sh -c '"[ \$(${local.etcd_test_command} | wc -l) == ${var.count} ] && ${local.etcd_test_command} | grep -q isLeader=true"'
-TEST
+    core@${module.k8s.private_ipv4_addrs[0]} -- \
+  CMD
 }
 
 output "tf_test" {
-  description = "This output can be used to check if the cluster is up & running by typing `terraform output tf_test | sh`"
+  description = "Used by module tests"
 
-  value = <<TEST
-ssh -o UserKnownHostsFile=/dev/null \
-    -o StrictHostKeyChecking=no \
-    -o ProxyCommand='ssh -o StrictHostKeyChecking=no core@${module.network.bastion_public_ip} ncat %h %p' \
-    core@${module.k8s.private_ipv4_addrs[0]} sh -c '"[ \$(${local.k8s_test_command} | grep master | grep -iw ready| wc -l) == ${var.count} ]"'
-TEST
+  value = <<CMD
+
+`# This output is only for test purpose!` \
+${replace("${local.test_ssh_prefix} sh -c \"'${module.k8s.etcd_status}'\"", "/\\s*\\\\\\s+/", " ")} \
+`# This output is only for test purpose!`
+CMD
 }
 
 output "helper" {
@@ -31,17 +31,19 @@ output "helper" {
   value = <<HELP
 Your kubernetes cluster is up.
 
-You can connect in one of the instances:
+Check if cluster is running:
 
-    ${indent(4, join( "\n",formatlist("$ ssh -J core@${module.network.bastion_public_ip} core@%s", module.k8s.private_ipv4_addrs)))}
+    $ ${indent(6, local.ssh_prefix)} sh -c \"'${indent(6, module.k8s.etcd_status)}'\" && echo 'etcd cluster is running'
 
-Check your etcd cluster:
+    $ ${indent(6, local.ssh_prefix)} sh -c \"'${indent(6, module.k8s.k8s_status)}'\" && echo 'k8s cluster is running'
 
-    $ ${local.etcd_test_command}
+Configure the client:
 
-Check your k8s cluster:
+    $ ${indent(6, local.ssh_prefix)} ${indent(6, module.k8s.k8s_get_config)} > ${local.k8s_config_path}
 
-    $ ${local.k8s_test_command}
+To connect to one of the instances:
+
+    ${indent(4, join( "\n", formatlist("$ ssh -J core@${module.network.bastion_public_ip} core@%s", module.k8s.private_ipv4_addrs)))}
 
 Run a pod:
 

--- a/examples/public-cluster-cl/README.md
+++ b/examples/public-cluster-cl/README.md
@@ -4,44 +4,44 @@
 - [Simple k8s cluster](#simple-k8s-cluster)
     - [Configuration](#configuration)
     - [Run it](#run-it)
+    - [Get started](#get-started)
     
 ## Install terraform
 
-You can information on how to install terraform [here](https://www.terraform.io/intro/getting-started/install.html)
+You can information on how to install terraform [here](https://www.terraform.io/intro/getting-started/install.html).
 
 ## Configuration
-1. Copy variable file
 
-There is an example of var file `terraform.tfvars.sample`.
+1. Copy variable file, then edit it if needed.
+   This allow terraform to autoload those variables
 
-Copy it under the name `terraform.tfvars` (this allow terraform to autoload those variables)
+   ```bash
+   cp terraform.tfvars.sample terraform.tfvars
+   ```
 
-2. Create a public cloud project on OVH
+2. Create a public cloud project on OVH following the [official documentation](https://docs.ovh.com/gb/en/public-cloud/getting_started_with_public_cloud_logging_in_and_creating_a_project/).
 
-Follow the [official documentation](https://docs.ovh.com/gb/en/public-cloud/getting_started_with_public_cloud_logging_in_and_creating_a_project/).
+   Create an Openstack user ([official documentation](https://docs.ovh.com/gb/en/public-cloud/configure_user_access_to_horizon/)).
+   Then download the Openstack configuration file. You can get it from [OVH Manager](https://www.ovh.com/manager/cloud/), or from [Horizon interface](https://horizon.cloud.ovh.net/project/api_access/openrc/).
 
-You will need to create an Openstack user. You can do so in the "Openstack" part of you cloud project. 
+   Source the configuration file:
 
-You add to source your openstack configuration file. You can generate this file for you user in OVH manager (Use the user contextual menu). 
+   ```bash
+   $ source openrc.sh
+   Please enter your OpenStack Password:
 
-```bash
-# Source openrc.sh
-$ source openrc.sh
-Please enter your OpenStack Password: 
+   ```
 
-```
+3. Create or reuse ssh key pair. Careful this keypair should not be using passphrase!
 
-3. Create or reuse ssh key pair. Carreful this keypair should not be using passphrase !
+   ```bash
+   # Generate a new keypair without passphrase
+   $ ssh-keygen -f terraform_ssh_key -q -N ""
+   # Add it to the ssh-agent
+   $ ssh-add terraform_ssh_key
+   ```
 
-```bash
-# Generate a new keypair without passphrase
-$ ssh-keygen -f terraform_ssh_key -q -N ""
-```
-
-If you generate a new keypair, put its path in `terraform.tfvars` under variable `public_sshkey` and add it to your ssh-agent:
-```bash
-$ ssh-add terraform_ssh_key
-```
+   If you generated a new keypair, set `public_sshkey` with its path in `terraform.tfvars`.
 
 ## Run it
 
@@ -55,28 +55,39 @@ Terraform has been successfully initialized!
 
 $ terraform apply
 [...]
-helper = Your kubernetes cluster is up.
-
-You can connect in one of the instances:
-
-    $ ssh core@<ip>
-
-Check your etcd cluster:
-
-    $ /opt/etcd/bin/etcdctl --ca-file /opt/etcd/certs/ca.pem --cert-file /opt/etcd/certs/cert.pem --key-file /opt/etcd/certs/cert-key.pem --endpoints https://54.36.112.50:2379 member list
-
-Run a pod:
-
-    $ ...
-
-Enjoy!
-
 
 ```
 
-This should give you an infra with :
+This should give you an infra with:
 
 * 3 kubernetes masters in a public network with:
   * Canal (Flannel + Calico) CNI
   * Untainted nodes (pods can run on masters)
   * kube-proxy for services
+
+## Get Started
+
+Get help with following command:
+
+```bash
+$ terraform output helper
+Your kubernetes cluster is up.
+
+Check if cluster is running:
+
+    $ [...]
+
+Configure the client:
+
+    $ [...]
+
+To connect to one of the instances:
+
+    $ [...]
+
+Run a pod:
+
+    $ [...]
+
+Enjoy!
+```

--- a/examples/public-cluster-cl/output.tf
+++ b/examples/public-cluster-cl/output.tf
@@ -1,42 +1,47 @@
 locals {
-  etcd_test_command = "/opt/etcd/bin/etcdctl --ca-file /opt/etcd/certs/ca.pem --cert-file /opt/etcd/certs/cert.pem --key-file /opt/etcd/certs/cert-key.pem --endpoints https://${module.k8s.public_ipv4_addrs[0]}:2379 member list"
-  k8s_test_command = "sudo /opt/k8s/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf get nodes"
-}
+  k8s_config_path = "~/.kube/config"
+  ssh_prefix      = "ssh core@${module.k8s.public_ipv4_addrs[0]} --"
 
-output "tf_test_etcd" {
-  description = "This output can be used to check if the cluster is up & running by typing `terraform output tf_test | sh`"
-  value = <<TEST
+  test_ssh_prefix = <<CMD
 ssh -o UserKnownHostsFile=/dev/null \
     -o StrictHostKeyChecking=no \
-    core@${module.k8s.public_ipv4_addrs[0]} sh -c '"[ \$(${local.etcd_test_command} | wc -l) == ${var.count} ] && ${local.etcd_test_command} | grep -q isLeader=true"'
-TEST
+    core@${module.k8s.public_ipv4_addrs[0]} -- \
+  CMD
 }
 
 output "tf_test" {
-  description = "This output can be used to check if the cluster is up & running by typing `terraform output tf_test | sh`"
-  value = <<TEST
-ssh -o UserKnownHostsFile=/dev/null \
-    -o StrictHostKeyChecking=no \
-    core@${module.k8s.public_ipv4_addrs[0]} sh -c '"[ \$(${local.k8s_test_command} | grep master | grep -iw ready| wc -l) == ${var.count} ]"'
-TEST
+  description = "Used by module tests"
+
+  # Inline `tf_test` output so we do not flood `tf apply` helper
+  # Warns user that he probably should not use this output
+  # the regex will match all new line ended by a backslash
+  value = <<CMD
+
+`# This output is only for test purpose!` \
+${replace("${local.test_ssh_prefix} sh -c \"'${module.k8s.etcd_status}'\"", "/\\s*\\\\\\s+/", " ")} \
+`# This output is only for test purpose!`
+CMD
 }
 
 output "helper" {
   description = "This output is a human friendly helper on how to interact with the k8s cluster"
+
   value = <<HELP
 Your kubernetes cluster is up.
 
-You can connect in one of the instances:
+Check if cluster is running:
 
-    ${indent(4, join( "\n",formatlist("$ ssh core@%s", module.k8s.public_ipv4_addrs)))}
+    $ ${indent(6, local.ssh_prefix)} sh -c \"'${indent(6, module.k8s.etcd_status)}'\" && echo 'etcd cluster is running'
 
-Check your etcd cluster:
+    $ ${indent(6, local.ssh_prefix)} sh -c \"'${indent(6, module.k8s.k8s_status)}'\" && echo 'k8s cluster is running'
 
-    $ ${local.etcd_test_command}
+Configure the client:
 
-Check your k8s cluster:
+    $ ${indent(6, local.ssh_prefix)} ${indent(6, module.k8s.k8s_get_config)} > ${local.k8s_config_path}
 
-    $ ${local.k8s_test_command}
+To connect to one of the instances:
+
+    ${join( "\n    ", formatlist("$ ssh core@%s", module.k8s.public_ipv4_addrs))}
 
 Run a pod:
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,22 @@
+locals {
+  k8s_admin_config = "/etc/kubernetes/admin.conf"
+
+  etcd_test_command = <<CMD
+/opt/etcd/bin/etcdctl \
+    --ca-file /opt/etcd/certs/ca.pem \
+    --cert-file /opt/etcd/certs/cert.pem \
+    --key-file /opt/etcd/certs/cert-key.pem \
+    --endpoints https://localhost:2379 \
+    member list \
+CMD
+
+  k8s_test_command = <<CMD
+sudo /opt/k8s/bin/kubectl \
+    --kubeconfig ${local.k8s_admin_config} \
+    get nodes \
+CMD
+}
+
 output "public_security_group_id" {
   value = "${join("", openstack_networking_secgroup_v2.pub.*.id)}"
 }
@@ -16,5 +35,24 @@ output "cfssl_endpoint" {
 
 output "etcd_initial_cluster" {
   description = "The etcd initial cluster that can be used to join the cluster"
-  value       = "${module.userdata.etcd_initial_cluster}"
+
+  value = "${module.userdata.etcd_initial_cluster}"
+}
+
+output "etcd_status" {
+  description = "This output can be used to check if the etcd cluster is up & running"
+
+  value = "[ \\$(${local.etcd_test_command}    | wc -l) == ${var.count} ] && ${local.etcd_test_command}    | grep -q isLeader=true"
+}
+
+output "k8s_status" {
+  description = "This output can be used to check if the k8s cluster is up & running"
+
+  value = "[ \\$(${local.k8s_test_command}    | grep master | grep -iw ready | wc -l) == ${var.count} ]"
+}
+
+output "k8s_get_config" {
+  description = "This output can be used to get config file"
+
+  value = "sudo cat ${local.k8s_admin_config}"
 }

--- a/test/runtest.sh
+++ b/test/runtest.sh
@@ -1,11 +1,13 @@
 #!/bin/bash -x
 
-DIR=${1:-$(dirname $0)/../examples/public-server}
+DIR=${1:-$(dirname $0)/../examples/public-cluster-cl}
 REGION=${2:-$OS_REGION_NAME}
 DESTROY=${3:-1}
 CLEAN=${4:-1}
 PROJECT=${OS_TENANT_ID}
 VRACK=${OVH_VRACK_ID}
+
+OUTPUT_TEST="tf_test"
 
 test_tf(){
     # timeout is not 60 seconds but 60 loops, each taking at least 1 sec
@@ -14,7 +16,7 @@ test_tf(){
     local res=1
 
     while [ "$res" -ne 0 ] && [ "$inc" -lt "$timeout" ]; do
-        (cd "${DIR}" && terraform output tf_test | sh)
+        (cd "${DIR}" && terraform output ${OUTPUT_TEST} | sh)
         res=$?
         sleep 1
         ((inc++))


### PR DESCRIPTION
```bash
$ tf output
helper = Your kubernetes cluster is up.

Check if cluster is running:

    $ ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no core@54.37.76.87 --  sh -c "'[ \$(/opt/etcd/bin/etcdctl --ca-file /opt/etcd/certs/ca.pem --cert-file /opt/etcd/certs/cert.pem --key-file /opt/etcd/certs/cert-key.pem --endpoints https://localhost:2379 member list | wc -l) == 3 ] && /opt/etcd/bin/etcdctl --ca-file /opt/etcd/certs/ca.pem --cert-file /opt/etcd/certs/cert.pem --key-file /opt/etcd/certs/cert-key.pem --endpoints https://localhost:2379 member list | grep -q isLeader=true'" && echo 'etcd cluster is running'

    $ ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no core@54.37.76.87 --  sh -c "'[ \$(sudo /opt/k8s/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf get nodes | grep master | grep -iw ready | wc -l) == 3 ]'" && echo 'k8s cluster is running'

Configure the client:

    $ ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no core@54.37.76.87 --  sudo cat /etc/kubernetes/admin.conf > ~/.kube/config

To connect to one of the instances:

    $ ssh core@54.37.76.87
    $ ssh core@54.36.112.230
    $ ssh core@54.36.113.63

Run a pod:

    $ ...

Enjoy!
```