### PR TITLE
Upgrade to kubernetes 1.9.6 and calico 2.6.8

### DIFF
--- a/modules/install-k8s/variables.tf
+++ b/modules/install-k8s/variables.tf
@@ -75,15 +75,15 @@ variable "k8s_sha1sum_cni_plugins" {
 
 variable "k8s_sha1sum_kubelet" {
   description = "The sha1 checksum of the k8s binary kubelet to install with the post installation script if `post_install_module` is set to true"
-  default     = "b27e42094c102fa0e053b69916b754746904bc8e"
+  default     = "32b1234e68d4d576c3fe0b62e608e361e09408a1"
 }
 
 variable "k8s_sha1sum_kubectl" {
   description = "The sha1 checksum of the k8s binary kubectl to install with the post installation script if `post_install_module` is set to true"
-  default     = "144534762b792c18f8d93c809b60c42f0826dd03"
+  default     = "04d344ac9b2a6514f0d94c2df79073e42d6c1182"
 }
 
 variable "k8s_sha1sum_kubeadm" {
   description = "The sha1 checksum of the k8s binary kubeadm to install with the post installation script if `post_install_module` is set to true"
-  default     = "248e1229ccd48e7be1c33252cd83b2f23a16acc2"
+  default     = "3eba73297aac155bcebc9d006eb1ca0cf7ff86f0"
 }

--- a/modules/install-k8s/variables.tf
+++ b/modules/install-k8s/variables.tf
@@ -35,12 +35,12 @@ variable "ssh_bastion_user" {
 
 variable "k8s_version" {
   description = "The version of k8s to install with the post installation script if `post_install_module` is set to true"
-  default     = "1.9.2"
+  default     = "1.9.6"
 }
 
 variable "calico_node_version" {
   description = "The version of calico_node to install with the post installation script if `post_install_module` is set to true"
-  default     = "2.6.7"
+  default     = "2.6.8"
 }
 
 variable "calico_cni_version" {

--- a/modules/k8s-userdata/k8s.tf
+++ b/modules/k8s-userdata/k8s.tf
@@ -61,7 +61,7 @@ networking:
   dnsDomain: ${var.datacenter}.${var.domain}
   serviceSubnet: ${var.service_cidr}
   podSubnet: ${var.pod_cidr}
-kubernetesVersion: 1.9.2
+kubernetesVersion: 1.9.6
 #DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.'
 nodeName: ${replace(lower(var.name), "/[^0-9a-z.-]/", "-")}-${count.index}
 authorizationModes:


### PR DESCRIPTION
Provisioning successful but some serious testing are needed (WIP):

```
NAME           STATUS    AGE       VERSION
k8s-master-0   Ready     12m       v1.9.6
k8s-master-1   Ready     11m       v1.9.6
k8s-master-2   Ready     12m       v1.9.6
k8s-worker-0   Ready     12m       v1.9.6
k8s-worker-1   Ready     12m       v1.9.6
```
