### PR TITLE
Delete existing keypair in travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
 - ./test/travis_setup.sh
 script:
 - export TF_VAR_name=TRAVIS_${TRAVIS_BUILD_NUMBER}
-- test/runtests.sh $OS_REGION_NAME publish
+- test/runtests.sh $OS_REGION_NAME publish delete_existing_keypair
 branches:
   only:
   - master

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -2,6 +2,7 @@
 
 REGIONS=${1:-$OS_REGION_NAME}
 PUBLISH=$2
+DELETE_EXISTING_KEYPAIR=$3
 BASEDIR="$(dirname $0)/.."
 TF_VAR_name=${TF_VAR_name:-test}
 TESTS=${TESTS:-public-cluster-cl public-cluster-cl-prebuilt private-cluster-cl public-cluster-with-workers-cl}
@@ -23,24 +24,33 @@ if ! ssh-add "${TEST_SSH_PRIVATE_KEY}"; then
     exit 1
 fi
 
-echo "creating openstack keypair according to test ssh key $TEST_SSH_PRIVATE_KEY" >&2
-if ! openstack keypair create --public-key "$TEST_SSH_PRIVATE_KEY.pub" "$TF_VAR_name"; then
-    echo "couldn't create test keypair. aborting" >&2
-    exit 1
-fi
-
 export TF_VAR_key_pair="$TF_VAR_name"
 export TF_VAR_public_sshkey="$TEST_SSH_PRIVATE_KEY.pub"
 ## end ssh setup
 
-# build packer image
-if ! (cd examples/k8s-glance-image && make coreos); then
-    echo "Image build failed. aborting" >&2
-    exit 1
-fi
+for r in $REGIONS; do
+    export OS_REGION_NAME="$r"
 
-for t in ${TESTS[@]}; do
-    for r in $REGIONS; do
+    # build packer image
+    if ! (cd examples/k8s-glance-image && make coreos); then
+        echo "Image build failed. aborting" >&2
+        exit 1
+    fi
+
+    # checking if keypair with same name already exists for test user. if so, delete it
+    # according to DELETE_EXISTING_KEYPAIR arg
+    if [ "$DELETE_EXISTING_KEYPAIR" == "delete_existing_keypair" ] && openstack keypair show -c id -f value "$TF_VAR_name"; then
+        echo "keypair with name $TF_VAR_name already exists. deleting" >&2
+        openstack  keypair delete "$TF_VAR_name"
+    fi
+
+    echo "creating openstack keypair according to test ssh key $TEST_SSH_PRIVATE_KEY" >&2
+    if ! openstack keypair create --public-key "$TEST_SSH_PRIVATE_KEY.pub" "$TF_VAR_name"; then
+        echo "couldn't create test keypair. aborting" >&2
+        exit 1
+    fi
+
+    for t in ${TESTS[@]}; do
         echo "running test $t on region $r." >&2
         if ! "$BASEDIR/test/runtest.sh" "$BASEDIR/examples/$t" "$r"; then
             echo "test $t on region $r failed. skipping nexts." >&2


### PR DESCRIPTION
Delete existitng keypair when running tests
If a travis test fails, it may leaves orphans
keypairs in OS env. This commit deletes keypair
before creating them
It also handles multiregions tests